### PR TITLE
add a standard .rubocop.yml file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,31 @@
+# Rocketships!!!!
+HashSyntax:
+  EnforcedStyle: hash_rockets
+
+# Enforce spaces within Braces
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+
+# Numbers without underscores, please.
+Style/NumericLiterals:
+  Enabled: false
+
+# Allow slightly longer classes
+Metrics/ClassLength:
+  CountComments: false
+  Max: 150
+
+# Allow sightly longer lines
+Metrics/LineLength:
+  Max: 120
+
+# Allow slightly longer methods
+Metrics/MethodLength:
+  Max: 50
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+    - space
+    - no_space

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Metrics/LineLength:
 
 # Allow slightly longer methods
 Metrics/MethodLength:
-  Max: 50
+  Max: 15
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,9 @@ HashSyntax:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
-# Numbers without underscores, please.
+# Numbers with underscores, please.
 Style/NumericLiterals:
-  Enabled: false
+  Enabled: true
 
 # Allow slightly longer classes
 Metrics/ClassLength:

--- a/README.md
+++ b/README.md
@@ -3644,6 +3644,8 @@ checker based on this style guide. RuboCop already covers a
 significant portion of the Guide, supports both MRI 1.9 and MRI 2.0
 and has good Emacs integration.
 
+Bulletproof's standard [.rubocop.yml](https://github.com/bulletproofnetworks/ruby-style-guide/blob/master/.gitattributes) is available in this repo.
+
 ### RubyMine
 
 [RubyMine](http://www.jetbrains.com/ruby/)'s code inspections are

--- a/README.md
+++ b/README.md
@@ -3644,7 +3644,7 @@ checker based on this style guide. RuboCop already covers a
 significant portion of the Guide, supports both MRI 1.9 and MRI 2.0
 and has good Emacs integration.
 
-Bulletproof's standard [.rubocop.yml](https://github.com/bulletproofnetworks/ruby-style-guide/blob/master/.gitattributes) is available in this repo.
+Bulletproof's standard [.rubocop.yml](https://github.com/bulletproofnetworks/ruby-style-guide/blob/master/.rubocop.yml) is available in this repo.
 
 ### RubyMine
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,0 +1,1 @@
+.rubocop.yml


### PR DESCRIPTION
Requesting to add a standard rubocop.yml file to our style guide.