### PR TITLE
Remove hashrockets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,3 @@
-# Rocketships!!!!
-HashSyntax:
-  EnforcedStyle: hash_rockets
-
 # Numbers with underscores, please.
 Style/NumericLiterals:
   Enabled: true

--- a/ruby-style-guide.gemspec
+++ b/ruby-style-guide.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'ruby-style-guide'
-  spec.version       = 0.3
+  spec.version       = 0.4
   spec.authors       = ['Manuel Socarras']
   spec.email         = ['manuel.socarras@bulletproof.net']
   spec.summary       = %q{Ruby style guide for Bulletproof Developers}


### PR DESCRIPTION
Hash rockets are an ancient way to write hashes. When we have projects starting in Rails 5 and ruby 2.3.1, we should not be enforcing them and move on to the new syntax of things. Though the actual style guide does mention that hashrockets are not the way to go, actual rubocop enforces everything to be that.
